### PR TITLE
Refactor repository helpers

### DIFF
--- a/src/runtime/components/workflow.tsx
+++ b/src/runtime/components/workflow.tsx
@@ -62,6 +62,7 @@ import {
   shouldShowWorkspaceLoading,
   toIsoLocal,
   fromIsoLocal,
+  toTrimmedString,
 } from "../../shared/utils"
 
 const DRAWING_MODE_TABS = [
@@ -82,14 +83,6 @@ const DRAWING_MODE_TABS = [
 ] as const
 
 const EMPTY_WORKSPACES: readonly WorkspaceItem[] = Object.freeze([])
-
-const toTrimmedString = (value?: string | null): string | undefined => {
-  if (typeof value !== "string") {
-    return undefined
-  }
-  const trimmed = value.trim()
-  return trimmed || undefined
-}
 
 const isNonEmptyString = (value: unknown): value is string =>
   typeof value === "string" && value.trim() !== ""

--- a/src/setting/setting.tsx
+++ b/src/setting/setting.tsx
@@ -7,6 +7,9 @@ import {
   safeAbort,
   parseNonNegativeInt,
   isValidEmail,
+  toTrimmedString,
+  collectTrimmedStrings,
+  uniqueStrings,
 } from "../shared/utils"
 import { logWarn } from "../shared/logging"
 import { useTheme } from "jimu-theme"
@@ -249,28 +252,17 @@ const RepositorySelector: React.FC<RepositorySelectorProps> = ({
       if (!hasValidServer || !hasValidToken) return []
       if (availableRepos === null) return []
 
-      const src =
-        Array.isArray(availableRepos) && availableRepos.length > 0
-          ? availableRepos
-          : []
+      const available = Array.isArray(availableRepos)
+        ? collectTrimmedStrings(availableRepos)
+        : []
 
-      const seen = new Set<string>()
-      const opts: Array<{ label: string; value: string }> = []
-      if (
-        localRepository &&
-        typeof localRepository === "string" &&
-        localRepository.trim()
-      ) {
-        seen.add(localRepository)
-        opts.push({ label: localRepository, value: localRepository })
-      }
-      for (const name of src) {
-        if (!seen.has(name) && typeof name === "string" && name.trim()) {
-          seen.add(name)
-          opts.push({ label: name, value: name })
-        }
-      }
-      return opts
+      const local = toTrimmedString(localRepository)
+      const names = uniqueStrings([
+        ...(local ? [local] : []),
+        ...available,
+      ])
+
+      return names.map((name) => ({ label: name, value: name }))
     }
   )
 

--- a/src/tests/utils.test.ts
+++ b/src/tests/utils.test.ts
@@ -21,6 +21,9 @@ import {
   getBtnAria,
   getErrorIconSrc,
   sanitizeParamKey,
+  collectTrimmedStrings,
+  uniqueStrings,
+  extractRepositoryNames,
   isPolygonGeometry,
   determineServiceMode,
   buildFmeParams,
@@ -142,6 +145,36 @@ describe("shared/utils", () => {
       expect(parseTableRows("[1,2,'x']")).toEqual(["[1,2,'x']"])
       expect(parseTableRows("plain")).toEqual(["plain"])
       expect(parseTableRows(123 as any)).toEqual([])
+    })
+
+    test("collectTrimmedStrings removes blanks and non-strings", () => {
+      expect(collectTrimmedStrings([" a ", "", null, 42, undefined])).toEqual([
+        "a",
+      ])
+    })
+
+    test("uniqueStrings preserves order and removes duplicates", () => {
+      expect(uniqueStrings(["a", "b", "a", "a", "c"])).toEqual([
+        "a",
+        "b",
+        "c",
+      ])
+    })
+
+    test("extractRepositoryNames handles arrays and nested collections", () => {
+      expect(
+        extractRepositoryNames([
+          { name: " RepoA " },
+          { name: "" },
+          { name: null },
+        ])
+      ).toEqual(["RepoA"])
+
+      expect(
+        extractRepositoryNames({
+          items: [{ name: "RepoB" }, { name: "RepoA" }],
+        })
+      ).toEqual(["RepoB", "RepoA"])
     })
 
     test("resolveMessageOrKey exact and camel-case", () => {


### PR DESCRIPTION
## Summary
- expand shared utilities with iterable helpers for trimmed string collection, deduplication, and repository name extraction
- refactor the API client and service layer to share the centralized repository parsing logic
- streamline the settings repository selector to reuse the shared helpers and cover them with unit tests

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68da8e886ea0832a8aac0f80b627e09f