### PR TITLE
Fix relative endpoint handling in resolveRequestUrl

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1017,8 +1017,20 @@ export const resolveRequestUrl = (
   basePath: string
 ): string => {
   if (endpoint.startsWith("http")) return endpoint
-  if (endpoint.startsWith("/fme")) return buildUrl(serverUrl, endpoint.slice(1))
-  return buildUrl(serverUrl, basePath.slice(1), endpoint.slice(1))
+
+  const stripLeadingSlash = (value: string): string =>
+    value.startsWith("/") ? value.slice(1) : value
+
+  if (endpoint.startsWith("/fme")) {
+    return buildUrl(serverUrl, stripLeadingSlash(endpoint))
+  }
+
+  const normalizedBase = stripLeadingSlash(basePath || "")
+  const normalizedEndpoint = stripLeadingSlash(endpoint)
+
+  return normalizedEndpoint
+    ? buildUrl(serverUrl, normalizedBase, normalizedEndpoint)
+    : buildUrl(serverUrl, normalizedBase)
 }
 
 export const buildParams = (

--- a/src/tests/api.test.ts
+++ b/src/tests/api.test.ts
@@ -364,8 +364,13 @@ describe("shared/api FmeFlowApiClient", () => {
     const esriRequest = (global as any).esriRequest as jest.Mock
     const client = makeClient()
 
+    await client.customRequest<any>("jobs", HttpMethod.GET)
+    let [url, opt] = esriRequest.mock.calls[0]
+    expect(url).toBe("https://fme.example.com/fmerest/v3/jobs")
+    expect(opt.method).toBe("get")
+
     await client.customRequest<any>("/custom", HttpMethod.GET, { x: 1 })
-    let [, opt] = esriRequest.mock.calls[0]
+    ;[, opt] = esriRequest.mock.calls[1]
     expect(opt.method).toBe("get")
     expect(opt.query.x).toBe(1)
 
@@ -375,7 +380,7 @@ describe("shared/api FmeFlowApiClient", () => {
       { a: "b" },
       "application/x-www-form-urlencoded"
     )
-    ;[, opt] = esriRequest.mock.calls[1]
+    ;[, opt] = esriRequest.mock.calls[2]
     expect(opt.method).toBe("post")
     expect(opt.body).toBe("a=b")
 
@@ -385,7 +390,7 @@ describe("shared/api FmeFlowApiClient", () => {
       { a: 1 },
       "application/json"
     )
-    ;[, opt] = esriRequest.mock.calls[2]
+    ;[, opt] = esriRequest.mock.calls[3]
     expect(opt.headers["Content-Type"]).toBe("application/json")
     expect(JSON.parse(opt.body)).toEqual({ a: 1 })
   })

--- a/src/tests/utils.test.ts
+++ b/src/tests/utils.test.ts
@@ -571,6 +571,9 @@ describe("shared/utils", () => {
       expect(resolveRequestUrl("/v3/jobs", "https://h", "/fmerest")).toBe(
         "https://h/fmerest/v3/jobs"
       )
+      expect(resolveRequestUrl("jobs", "https://h", "/fmerest/v3")).toBe(
+        "https://h/fmerest/v3/jobs"
+      )
     })
 
     test("buildParams handles primitives, files, and defaults", () => {


### PR DESCRIPTION
## Summary
- avoid stripping the first character from relative endpoints in `resolveRequestUrl`
- cover raw relative paths in utils and API client custom request tests

## Testing
- not run (tests unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68da943df49c832aa659fd6c071f92f8