### PR TITLE
Add helper translation for masking email on success

### DIFF
--- a/src/setting/translations/default.ts
+++ b/src/setting/translations/default.ts
@@ -56,6 +56,8 @@ export default {
   serviceModeSyncHelper:
     "På: nedladdning via direktlänk i webbläsaren. Av: länk skickas med e‑post.",
   maskEmailOnSuccess: "Maskera e‑postadress",
+  maskEmailOnSuccessHelper:
+    "Döljer större delen av e‑postadressen i lyckade svar (visar endast början och domänen).",
   supportEmailHelper:
     "Om en adress anges visas den i felmeddelanden som supportkontakt.",
   requestTimeoutLabel: "Tidsgräns för begäran (ms)",


### PR DESCRIPTION
## Summary
- add Swedish helper tooltip text for the mask email on success setting
- verified no other locale files exist that require an update

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3ef104898832abd0a820cb985b87d