### PR TITLE
Prevent opt_geturl from overriding uploaded datasets

### DIFF
--- a/src/runtime/widget.tsx
+++ b/src/runtime/widget.tsx
@@ -300,6 +300,13 @@ const resolveRemoteDataset = async ({
     return
   }
 
+  // When uploading a dataset we must clear any lingering opt_geturl value to
+  // avoid conflicting inputs. Otherwise a previously valid remote URL would
+  // override the uploaded dataset. (SRP & defensive programming)
+  if (typeof params.opt_geturl !== "undefined") {
+    delete params.opt_geturl
+  }
+
   const uploadResponse = await makeCancelable<ApiResponse<{ path: string }>>(
     fmeClient.uploadToTemp(uploadFile, {
       subfolder,

--- a/src/tests/widget.test.tsx
+++ b/src/tests/widget.test.tsx
@@ -299,6 +299,39 @@ describe("remote dataset resolution", () => {
     expect(params).not.toHaveProperty("opt_geturl")
     expect(params.UploadParam).toBe("/temp/uploaded/path")
   })
+
+  it("removes opt_geturl when uploading a dataset even if remote URLs are allowed", async () => {
+    const file = makeFile()
+    const params: MutableParams = {
+      opt_geturl: "https://datasets.example.com/old.zip",
+    }
+    const uploadResponse = {
+      data: { path: "/temp/uploaded/path" },
+      status: 200,
+      statusText: "OK",
+    }
+    const fmeClient = {
+      uploadToTemp: jest.fn().mockResolvedValue(uploadResponse),
+    }
+
+    await resolveRemoteDataset({
+      params,
+      remoteUrl: "",
+      uploadFile: file,
+      config: makeConfig({
+        allowRemoteDataset: true,
+        allowRemoteUrlDataset: true,
+      }),
+      workspaceParameters: [],
+      makeCancelable,
+      fmeClient: fmeClient as any,
+      signal: new AbortController().signal,
+      subfolder: "temp",
+    })
+
+    expect(params).not.toHaveProperty("opt_geturl")
+    expect(params.SourceDataset).toBe("/temp/uploaded/path")
+  })
 })
 
 describe("prepareSubmissionParams", () => {


### PR DESCRIPTION
## Summary
- clear any lingering opt_geturl parameter before uploading a dataset so the new file path wins
- add a regression test that ensures uploaded datasets take precedence even when remote URLs are allowed

## Testing
- not run (package.json missing)

------
https://chatgpt.com/codex/tasks/task_e_68e4b9a1bcc8832a9211c50a095b750f